### PR TITLE
Remove redundant ternary operator in conditional check

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -8755,7 +8755,7 @@ SDValue TargetLowering::expandIS_FPCLASS(EVT ResultVT, SDValue Op,
       ISD::CondCode OrderedOp = IsInverted ? ISD::SETUGE : ISD::SETOLT;
       ISD::CondCode UnorderedOp = IsInverted ? ISD::SETOGE : ISD::SETULT;
 
-      if (isCondCodeLegalOrCustom(IsOrdered ? OrderedOp : UnorderedOp,
+      if (isCondCodeLegalOrCustom(UnorderedOp,
                                   OperandVT.getScalarType().getSimpleVT())) {
         // (issubnormal(x) || iszero(x)) --> fabs(x) < smallest_normal
 


### PR DESCRIPTION
The ternary operator in the second `if` statement was redundant because `IsOrdered` is already checked to be `false` in the outer `if` statement. Simplified the code by directly using `UnorderedOp`.